### PR TITLE
fix: Use new-address command to replace the hardcoded iota_config files format

### DIFF
--- a/become_candidate.sh
+++ b/become_candidate.sh
@@ -8,12 +8,12 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -f "./validator.info" ]; then
-    echo "Error: validator.info file not found"
+if [ ! -f "./key-pairs/validator.info" ]; then
+    echo "Error: ./key-pairs/validator.info file not found"
     exit 1
 fi
 
-cat ./validator.info
+cat ./key-pairs/validator.info
 
 read -p "Are your hostname, node info, etc. correct? [y/N] " response
 if [[ ! $response =~ ^[Yy]$ ]]; then
@@ -26,5 +26,5 @@ if docker run --rm -v ./iota_config:/root/.iota/iota_config $IOTA_DOCKER_IMAGE /
     sleep 2
     
     echo "Sending request to be candidate..."
-    docker run --rm -v ./iota_config:/root/.iota/iota_config -v ./validator.info:/iota/validator.info $IOTA_DOCKER_IMAGE /bin/sh -c "/usr/local/bin/iota validator become-candidate /iota/validator.info"
+    docker run --rm -v ./iota_config:/root/.iota/iota_config -v ./key-pairs/validator.info:/iota/validator.info $IOTA_DOCKER_IMAGE /bin/sh -c "/usr/local/bin/iota validator become-candidate /iota/validator.info"
 fi

--- a/generate_validator_info.sh
+++ b/generate_validator_info.sh
@@ -31,7 +31,7 @@ mkdir -p ./iota_config
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 mkdir -p "./tmp/backup_${TIMESTAMP}"
 
-NEW_ADDRESS_OUTPUT=$(docker run --rm -v ./iota_config:/root/.iota/iota_config "${IOTA_DOCKER_IMAGE}" /bin/sh -c '/usr/local/bin/iota client -y new-address ed25519 --json 2>&1')
+NEW_ADDRESS_OUTPUT=$(docker run --rm -v ./iota_config:/root/.iota/iota_config "${IOTA_DOCKER_IMAGE}" /bin/sh -c '/usr/local/bin/iota client -y new-address --json 2>&1')
 
 IOTA_ADDRESS=$(echo "$NEW_ADDRESS_OUTPUT" | sed -n '/{/,/}/p' | jq -r '.address')
 

--- a/generate_validator_info.sh
+++ b/generate_validator_info.sh
@@ -3,6 +3,22 @@
 IOTA_DOCKER_IMAGE=${IOTA_TOOLS_DOCKER_IMAGE:-"iotaledger/iota-tools:testnet"}
 API_URL=${IOTA_API_ENDPOINT:-"https://api.testnet.iota.cafe"}
 
+if ! command -v jq &> /dev/null; then
+    echo "jq is not installed. Installing jq..."
+    apt update && apt install -y jq
+fi
+
+if [ -d "./iota_config" ] || [ -d "./key-pairs" ]; then
+    read -p "./iota_config or key-pairs Directory already exists. This will overwrite everything? [y/N] " response
+    if [[ ! $response =~ ^[Yy]$ ]]; then
+        echo "Operation cancelled"
+        exit 1
+    fi
+
+    rm -r ./iota_config
+    rm -r ./key-pairs
+fi
+
 echo "Will using ${API_URL} for iota_config API endpopint"
 
 ./check_iota_services.sh --api ${API_URL} --docker ${IOTA_DOCKER_IMAGE}
@@ -10,64 +26,22 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if ! command -v jq &> /dev/null; then
-    echo "jq is not installed. Installing jq..."
-    apt update && apt install -y jq
-fi
-
-if [ -d "./key-pairs" ]; then
-    read -p "Key Pairs Directory already exists. This will overwrite everything? [y/N] " response
-    if [[ ! $response =~ ^[Yy]$ ]]; then
-        echo "Operation cancelled"
-        exit 1
-    fi
-    
-    TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-    BACKUP_DIR="key-pairs_backup_${TIMESTAMP}"
-    cp -r ./key-pairs "${BACKUP_DIR}"
-    rm -r ./key-pairs
-fi
-
 mkdir -p ./key-pairs
 mkdir -p ./iota_config
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-mkdir -p "./tmp/key-pairs-for-making-info_${TIMESTAMP}"
+mkdir -p "./tmp/backup_${TIMESTAMP}"
 
-KEYGEN_OUTPUT=$(docker run --rm ${IOTA_DOCKER_IMAGE} /bin/sh -c '/usr/local/bin/iota keytool generate ed25519 --json && cat *.key')
+NEW_ADDRESS_OUTPUT=$(docker run --rm -v ./iota_config:/root/.iota/iota_config "${IOTA_DOCKER_IMAGE}" /bin/sh -c '/usr/local/bin/iota client -y new-address ed25519 --json 2>&1')
 
-JSON_PART=$(echo "$KEYGEN_OUTPUT" | head -n-1)
+IOTA_ADDRESS=$(echo "$NEW_ADDRESS_OUTPUT" | sed -n '/{/,/}/p' | jq -r '.address')
 
-IOTA_ADDRESS=$(echo "$JSON_PART" | jq -r '.iotaAddress')
-PUBLIC_KEY=$(echo "$JSON_PART" | jq -r '.publicBase64Key')
-ACCOUNT_BECH32_PRIVATE_KEY=$(echo "$KEYGEN_OUTPUT" | tail -n1)
 
-cat > ./iota_config/client.yaml << EOF
----
-keystore:
-  File: /root/.iota/iota_config/iota.keystore
-envs:
-  - alias: custom
-    rpc: "${API_URL}"
-    ws: ~
-    basic_auth: ~
-active_env: custom
-active_address: "${IOTA_ADDRESS}"
-EOF
+if [ -z "$IOTA_ADDRESS" ] || [ "$IOTA_ADDRESS" = "null" ]; then
+    echo "Error: Failed to generate IOTA address"
+    exit 1
+fi
 
-cat > ./iota_config/iota.aliases << EOF
-[
-  {
-    "alias": "flamboyant-hematite", 
-    "public_key_base64": "${PUBLIC_KEY}"
-  }
-]
-EOF
-
-cat > ./iota_config/iota.keystore << EOF
-[ 
-    "${ACCOUNT_BECH32_PRIVATE_KEY}"
-]
-EOF
+cp -r ./iota_config "./tmp/backup_${TIMESTAMP}/iota_config"
 
 read -p "Enter validator name: " NAME
 read -p "Enter validator description: " DESCRIPTION
@@ -78,13 +52,14 @@ read -p "Enter hostname: " HOST_NAME
 IMAGE_URL=${IMAGE_URL:-""}
 PROJECT_URL=${PROJECT_URL:-""}
 
-docker run --rm -v ./iota_config:/root/.iota/iota_config -v "./tmp/key-pairs-for-making-info_${TIMESTAMP}":/iota ${IOTA_DOCKER_IMAGE} /bin/sh -c "RUST_BACKTRACE=full /usr/local/bin/iota validator make-validator-info \"$NAME\" \"$DESCRIPTION\" \"$IMAGE_URL\" \"$PROJECT_URL\" \"$HOST_NAME\" 1000"
+docker run --rm -v ./iota_config:/root/.iota/iota_config -v "./key-pairs":/iota ${IOTA_DOCKER_IMAGE} /bin/sh -c "RUST_BACKTRACE=full /usr/local/bin/iota validator make-validator-info \"$NAME\" \"$DESCRIPTION\" \"$IMAGE_URL\" \"$PROJECT_URL\" \"$HOST_NAME\" 1000"
 
-cp "./tmp/key-pairs-for-making-info_${TIMESTAMP}/account.key" ./key-pairs/account.key
-cp "./tmp/key-pairs-for-making-info_${TIMESTAMP}/network.key" ./key-pairs/network.key
-cp "./tmp/key-pairs-for-making-info_${TIMESTAMP}/protocol.key" ./key-pairs/protocol.key
-cp "./tmp/key-pairs-for-making-info_${TIMESTAMP}/authority.key" ./key-pairs/authority.key
-cp "./tmp/key-pairs-for-making-info_${TIMESTAMP}/validator.info" .
+if [ ! "$(ls -A ./key-pairs)" ]; then
+    echo "Error: Failed to generate validator info"
+    exit 1
+fi
+
+cp -r ./key-pairs "./tmp/backup_${TIMESTAMP}/key-pairs"
 
 echo -e "\nPlease share the following information in Slack:"
 echo -e "\nValidator Address: ${IOTA_ADDRESS}"


### PR DESCRIPTION
- fix: Use new-address command to replace the hardcoded iota_config files format
- feat: Backup iota_config and validator key pairs